### PR TITLE
Plugins/protectedcorporadb master

### DIFF
--- a/korpplugins/protectedcorporadb/__init__.py
+++ b/korpplugins/protectedcorporadb/__init__.py
@@ -81,6 +81,7 @@ class ProtectedCorporaDatabase(korppluginlib.KorpCallbackPlugin):
                     self._connection = None
             except (AttributeError, MySQLdb.MySQLError, MySQLdb.InterfaceError,
                     MySQLdb.DatabaseError):
+                # FIXME: do we want logging here or not convert the error? --mma 22.11.2023
                 raise ConnectionError
 
         return protected_corpora

--- a/korpplugins/protectedcorporadb/__init__.py
+++ b/korpplugins/protectedcorporadb/__init__.py
@@ -80,9 +80,7 @@ class ProtectedCorporaDatabase(korppluginlib.KorpCallbackPlugin):
                     self._connection.close()
                     self._connection = None
             except (AttributeError, MySQLdb.MySQLError, MySQLdb.InterfaceError,
-                    MySQLdb.DatabaseError) as e:
-                # Assume that no corpora are protected if trying to access the
-                # database results in an error
+                    MySQLdb.DatabaseError):
                 raise ConnectionError
 
         return protected_corpora


### PR DESCRIPTION
@aajarven you were right to comment that the removed comment below does not make sense. I actually though so yesterday and even today, but it does not. The "as e" was indeed a leftover. I do not want to decide what to log and if at all, but a reminder seemed in order.