### PR TITLE
KP-8262 Bump requirements to Python 3 compatible state

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ Flask==1.0
 Flask-Cors==3.0.4
 Flask-MySQLdb==0.2.0
 mysqlclient==1.3.13
-gevent==1.2.2
+gevent==21.12
 pylibmc==1.6.0
 python-dateutil==2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ mysqlclient==1.3.13
 gevent==21.12
 pylibmc==1.6.0
 python-dateutil==2.8.0
+jinja2<3.0
+markupsafe<2.1.0
+itsdangerous<2.1.0


### PR DESCRIPTION
NB: these have not been tested with Python 2: if we still need Python 2, this should not be blindly merged.