### PR TITLE
`korp.cgi`: Fix to decode CQP error output to string early enough

### DIFF
--- a/korp.cgi
+++ b/korp.cgi
@@ -3393,12 +3393,12 @@ def runCQP(command, form, executable=config.CQP_EXECUTABLE, registry=config.CWB_
     reply, error = process.communicate(command)
     if error and errors != "ignore":
         # remove newlines from the error string:
-        error = re.sub(r"\s+", r" ", error)
+        error = re.sub(r"\s+", r" ", error.decode(encoding, errors="ignore"))
         if errors == "report":
             # Each error on its own line beginning with "CQP Error"
             # (Jyrki Niemi 2017-12-13)
             error = re.sub(r" +(CQP Error: *)", r"\n\1", error)
-            for line in error.decode(encoding, errors="ignore").splitlines():
+            for line in error.splitlines():
                 yield line
         else:
             # keep only the first CQP error (the rest are consequences):


### PR DESCRIPTION
This fixes the Python 3 version of `korp.cgi` to work in cases where the CQP subprocess produces error output. Previously, such cases resulted in the `TypeError` “cannot use a string pattern on a bytes-like object”.

This _may_ also fix downloading Korp KWIC results from multiple corpora with different attributes.

Note that the base branch [`master-v2.8`](../tree/master-v2.8) contains the old Korp backend (version 2.8) implemented as CGI scripts. The branch incorporates the commits in [Kielipankki-korp-ansible](../../Kielipankki-korp-ansible) that converted the CGI scripts from Python 2 to Python 3. (I think it would probably be better to make Kielipankki-korp-ansible use the code here instead of having its own copy of the code.)