### PR TITLE
KP-10718 Bump gevent version to same as future

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==1.0
 Flask-Cors==3.0.4
 Flask-MySQLdb==0.2.0
 mysqlclient==1.3.13
-gevent==21.12
+gevent==25.5.1
 pylibmc==1.6.0
 python-dateutil==2.8.0
 jinja2<3.0


### PR DESCRIPTION
Until now, our Ansible has been installing newest gevent, despite installing much older versions of other packages, including initially gevent. This will make gevent the same version that doesn't break korp-future.

To be discussed: should we also bump other versions? Future has:

```
Flask~=3.1.2
Flask-Cors==6.0.1
Flask-MySQLdb==2.0.0
mysqlclient==2.2.7
gevent~=25.5.1
psutil~=7.1.0
pymemcache~=4.0.0
python-dateutil~=2.9.0
PyYAML~=6.0.3
```

Master (at this commit) has:

```
Flask==1.0
Flask-Cors==3.0.4
Flask-MySQLdb==0.2.0
mysqlclient==1.3.13
gevent==25.5.1
pylibmc==1.6.0
python-dateutil==2.8.0
jinja2<3.0
markupsafe<2.1.0
itsdangerous<2.1.0
```