### PR TITLE
KP-10997 Add support for ACA and RES in .info

### DIFF
--- a/config.py
+++ b/config.py
@@ -81,12 +81,7 @@ PLUGINS_CONFIG = {
     # Example auth_jwt plugin configuration:
     # "plugins.auth_jwt": {
     #     "pubkey_file": "path/to/pubkey.pem",
-    #     "licensing_mode": "språkbanken",  # or "kielipankki"
     # }
-    #
-    # licensing_mode options:
-    # - "språkbanken" (default): All Protected: true corpora require explicit grant in JWT scope.corpora
-    # - "kielipankki": Extended mode with License field support (ACA, ACA-Fi, RES)
 }
 
 # Show plugin information in the result of the /info endpoint:

--- a/config.py
+++ b/config.py
@@ -77,7 +77,17 @@ CHECK_AVAILABLE_CORPORA_STRICTLY = True
 PLUGINS = []
 
 # Plugin configuration
-PLUGINS_CONFIG = {}
+PLUGINS_CONFIG = {
+    # Example auth_jwt plugin configuration:
+    # "auth_jwt": {
+    #     "pubkey_file": "path/to/pubkey.pem",
+    #     "licensing_mode": "språkbanken",  # or "kielipankki"
+    # }
+    #
+    # licensing_mode options:
+    # - "språkbanken" (default): All Protected: true corpora require explicit grant in JWT scope.corpora
+    # - "kielipankki": Extended mode with License field support (ACA, ACA-Fi, RES)
+}
 
 # Show plugin information in the result of the /info endpoint:
 #  "name" = plugin names only

--- a/config.py
+++ b/config.py
@@ -79,7 +79,7 @@ PLUGINS = []
 # Plugin configuration
 PLUGINS_CONFIG = {
     # Example auth_jwt plugin configuration:
-    # "auth_jwt": {
+    # "plugins.auth_jwt": {
     #     "pubkey_file": "path/to/pubkey.pem",
     #     "licensing_mode": "språkbanken",  # or "kielipankki"
     # }

--- a/plugins/auth_jwt.py
+++ b/plugins/auth_jwt.py
@@ -9,11 +9,11 @@ Språkbanken mode (upstream/default):
 
 Kielipankki mode (extended):
 - License: ACA → Requires JWT ACA flag (academic affiliation)
-- License: ACA-Fi → Requires JWT ACA_Fi flag (Finnish academic status)
+- License: ACA-Fi → Requires JWT "ACA-Fi" flag (Finnish academic status)
 - License: RES → Requires explicit grant in JWT scope.corpora
 - No License field → Requires explicit grant in JWT scope.corpora (same as Språkbanken)
 
-Note: .info files use "ACA-Fi" with hyphen, but JWT uses "ACA_Fi" with underscore.
+Note: .info files use "ACA-Fi" with hyphen, and JWT also uses "ACA-Fi" (quoted key).
 """
 
 import time
@@ -108,9 +108,9 @@ class AuthJWT(utils.Authorizer):
                     # ACA license requires academic status
                     if not user_token or not user_token.get("ACA"):
                         unauthorized.append(corpus_upper)
-                elif license_value == "ACA-FI":
+                elif license_value == "ACA-Fi":
                     # ACA-Fi license requires Finnish academic status
-                    if not user_token or not user_token.get("ACA_Fi"):
+                    if not user_token or not user_token.get("ACA-Fi"):
                         unauthorized.append(corpus_upper)
                 elif license_value == "RES":
                     # RES license requires explicit grant in scope

--- a/plugins/auth_jwt.py
+++ b/plugins/auth_jwt.py
@@ -1,4 +1,13 @@
-"""Authorization using JWT."""
+"""Authorization using JWT.
+
+Supports three access levels:
+- PUB (public): No Protected field in .info, accessible to all
+- ACA (academic): Protected: ACA in .info, requires academic affiliation (JWT ACA flag)
+- RES (restricted): Protected: RES in .info, requires explicit entitlement grant in JWT scope
+
+Additionally, mink-* corpora (user-uploaded) use Protected: true/yes and require
+explicit user grants in JWT scope.
+"""
 
 import time
 from pathlib import Path
@@ -21,7 +30,10 @@ class AuthJWT(utils.Authorizer):
         self._pubkey = None
 
     def get_protected_corpora(self, use_cache: bool = True) -> List[str]:
-        """Get list of corpora with restricted access."""
+        """Get list of corpora with restricted access.
+
+        Returns all protected corpora (ACA, RES, and true/yes) as a flat list.
+        """
         if use_cache:
             with memcached.get_client() as mc:
                 key = f"protected:{utils.cache_prefix(mc)}"
@@ -35,7 +47,8 @@ class AuthJWT(utils.Authorizer):
         corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": list(corpora)}))
         protected_corpora = []
         for corpus, c_info in corpus_info["corpora"].items():
-            if c_info["info"].get("Protected", "false").lower() == "true":
+            protected_value = c_info["info"].get("Protected", "").lower()
+            if protected_value in ("aca", "res", "true", "yes"):
                 protected_corpora.append(corpus.upper())
 
         if use_cache:
@@ -44,26 +57,61 @@ class AuthJWT(utils.Authorizer):
         return protected_corpora
 
     def check_authorization(self, corpora: List[str]) -> Tuple[bool, List[str], Optional[str]]:
-        protected = self.get_protected_corpora()
-        if protected:
-            user_corpora = []
+        """Check if user is authorized to access the given corpora.
 
-            # Get authorization header
-            auth_header = request.headers.get("Authorization")
-            if auth_header and " " in auth_header:
-                auth_token = auth_header.split(" ")[1]
+        Authorization rules:
+        - ACA corpora: User must have ACA (academic) status in JWT
+        - RES corpora: User must have explicit entitlement grant in JWT scope.corpora
+        - true/yes corpora (incl. mink-*): User must have explicit user grant in JWT scope.corpora
 
-                # Parse JWT
-                user_token = jwt.decode(auth_token, key=self.jwt_key, algorithms=["RS256"])
-                if user_token["exp"] < time.time():
-                    return False, [], "The provided JWT has expired"
+        Returns:
+            Tuple of (success, unauthorized_corpora, error_message)
+        """
+        protected_set = set(self.get_protected_corpora())
 
-                for corpus, level in user_token.get("scope", {}).get("corpora", {}).items():
-                    user_corpora.append(corpus.upper())
+        # Find which requested corpora need authorization
+        corpora_to_check = [c.upper() for c in corpora if c.upper() in protected_set]
 
-            unauthorized = [c.upper() for c in corpora if c.upper() in protected and c.upper() not in user_corpora]
-            if unauthorized:
-                return False, unauthorized, None
+        if not corpora_to_check:
+            return True, [], None
+
+        # Parse JWT if present
+        user_token = None
+        user_scope_corpora = set()
+
+        auth_header = request.headers.get("Authorization")
+        if auth_header and " " in auth_header:
+            auth_token = auth_header.split(" ")[1]
+
+            # Parse JWT
+            user_token = jwt.decode(auth_token, key=self.jwt_key, algorithms=["RS256"])
+            if user_token["exp"] < time.time():
+                return False, [], "The provided JWT has expired"
+
+            # Collect user's granted corpora from scope
+            for corpus in user_token.get("scope", {}).get("corpora", {}).keys():
+                user_scope_corpora.add(corpus.upper())
+
+        # Get protection types for corpora that need checking
+        corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": corpora_to_check}))
+
+        # Check authorization for each corpus
+        unauthorized = []
+        for corpus_upper in corpora_to_check:
+            protected_value = corpus_info.get("corpora", {}).get(
+                corpus_upper, {}).get("info", {}).get("Protected", "").lower()
+
+            if protected_value == "aca":
+                # ACA corpora require academic status
+                if not user_token or not user_token.get("ACA"):
+                    unauthorized.append(corpus_upper)
+            elif protected_value in ("res", "true", "yes"):
+                # RES and true/yes corpora require explicit grant in scope
+                if corpus_upper not in user_scope_corpora:
+                    unauthorized.append(corpus_upper)
+
+        if unauthorized:
+            return False, unauthorized, None
         return True, [], None
 
     @property

--- a/plugins/auth_jwt.py
+++ b/plugins/auth_jwt.py
@@ -92,44 +92,45 @@ class AuthJWT(utils.Authorizer):
             for corpus in user_token.get("scope", {}).get("corpora", {}).keys():
                 user_scope_corpora.add(corpus.upper())
 
-        # Språkbanken mode: all protected corpora require explicit grant in scope
-        if licensing_mode == "språkbanken":
-            unauthorized = [c.upper() for c in corpora_to_check if c.upper() not in user_scope_corpora]
+        # Kielipankki mode: check License field for authorization type
+        if licensing_mode == "kielipankki":
+            # Get license types for corpora that need checking
+            # Always bypass cache for security: .info file changes don't trigger cache invalidation
+            corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": corpora_to_check, "cache": False}))
+
+            # Check authorization for each corpus
+            unauthorized = []
+            for corpus_upper in corpora_to_check:
+                c_info = corpus_info.get("corpora", {}).get(corpus_upper, {}).get("info", {})
+                license_value = c_info.get("License", "").upper()
+
+                if license_value == "ACA":
+                    # ACA license requires academic status
+                    if not user_token or not user_token.get("ACA"):
+                        unauthorized.append(corpus_upper)
+                elif license_value == "ACA-FI":
+                    # ACA-Fi license requires Finnish academic status
+                    if not user_token or not user_token.get("ACA_Fi"):
+                        unauthorized.append(corpus_upper)
+                elif license_value == "RES":
+                    # RES license requires explicit grant in scope
+                    if corpus_upper not in user_scope_corpora:
+                        unauthorized.append(corpus_upper)
+                else:
+                    # No License field or other value requires explicit grant in scope
+                    if corpus_upper not in user_scope_corpora:
+                        unauthorized.append(corpus_upper)
+
             if unauthorized:
                 return False, unauthorized, None
             return True, [], None
 
-        # Kielipankki mode: check License field for authorization type
-        # Get license types for corpora that need checking
-        # Always bypass cache for security: .info file changes don't trigger cache invalidation
-        corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": corpora_to_check, "cache": False}))
-
-        # Check authorization for each corpus
-        unauthorized = []
-        for corpus_upper in corpora_to_check:
-            c_info = corpus_info.get("corpora", {}).get(corpus_upper, {}).get("info", {})
-            license_value = c_info.get("License", "").upper()
-
-            if license_value == "ACA":
-                # ACA license requires academic status
-                if not user_token or not user_token.get("ACA"):
-                    unauthorized.append(corpus_upper)
-            elif license_value == "ACA-FI":
-                # ACA-Fi license requires Finnish academic status
-                if not user_token or not user_token.get("ACA_Fi"):
-                    unauthorized.append(corpus_upper)
-            elif license_value == "RES":
-                # RES license requires explicit grant in scope
-                if corpus_upper not in user_scope_corpora:
-                    unauthorized.append(corpus_upper)
-            else:
-                # No License field or other value requires explicit grant in scope
-                if corpus_upper not in user_scope_corpora:
-                    unauthorized.append(corpus_upper)
-
-        if unauthorized:
-            return False, unauthorized, None
-        return True, [], None
+        # Default mode (Språkbanken): all protected corpora require explicit grant in scope
+        else:
+            unauthorized = [c.upper() for c in corpora_to_check if c.upper() not in user_scope_corpora]
+            if unauthorized:
+                return False, unauthorized, None
+            return True, [], None
 
     @property
     def jwt_key(self):

--- a/plugins/auth_jwt.py
+++ b/plugins/auth_jwt.py
@@ -2,8 +2,8 @@
 
 For corpora with Protected: true in the .info file:
 - If corpus is in JWT scope.corpora (explicit grant), it's authorized
-- Otherwise, if License field is present in .info, check if JWT has that license key as truthy value
-  (e.g., License: ACA → requires jwt["ACA"], License: ACA-Fi → requires jwt["ACA-Fi"])
+- Otherwise, if License field is present in .info, check if JWT userClasses contains that license
+  (e.g., License: ACA → requires "ACA" in jwt["userClasses"], License: ACA-Fi → requires "ACA-Fi" in jwt["userClasses"])
 - Otherwise, it's not authorized
 
 """
@@ -37,7 +37,7 @@ class AuthJWT(utils.Authorizer):
         monitors registry files, not .info files, so cached protection status could
         become stale when .info files are edited.
         """
-        # Always bypass cache for security: .info file changes don't trigger cache invalidation
+        # Bypass cache for security: .info file changes don't trigger cache invalidation
         corpora = cwb.run_cqp("show corpora;")
         next(corpora)  # Skip version number
         corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": list(corpora), "cache": False}))
@@ -52,7 +52,7 @@ class AuthJWT(utils.Authorizer):
     def check_authorization(self, corpora: List[str]) -> Tuple[bool, List[str], Optional[str]]:
         """Check if user is authorized to access the given corpora.
 
-        For corpora with License field: check if JWT has that license key as truthy.
+        For corpora with License field: check if JWT userClasses contains that license.
         For corpora without License field: check if corpus is in JWT scope.corpora.
 
         Returns:
@@ -100,7 +100,7 @@ class AuthJWT(utils.Authorizer):
                 .get("info", {})
                 .get("License", "")
             )
-            if license_value and user_token.get(license_value):
+            if license_value and license_value in user_token.get("userClasses", []):
                 continue
             unauthorized.append(corpus_upper)
 

--- a/plugins/auth_jwt.py
+++ b/plugins/auth_jwt.py
@@ -1,11 +1,12 @@
 """Authorization using JWT.
 
-Supports three access levels:
-- PUB (public): No Protected field in .info, accessible to all
-- ACA (academic): Protected: ACA in .info, requires academic affiliation (JWT ACA flag)
-- RES (restricted): Protected: RES in .info, requires explicit entitlement grant in JWT scope
+Supports multiple access levels based on License type:
+- PUB (public): Protected: false or absent in .info, accessible to all
+- ACA (academic): Protected: true, License: ACA - requires academic affiliation (JWT ACA flag)
+- ACA-Fi (Finnish academic): Protected: true, License: ACA-Fi - requires Finnish academic status (JWT ACA-Fi flag)
+- RES (restricted): Protected: true, License: RES - requires explicit entitlement grant in JWT scope
 
-Additionally, mink-* corpora (user-uploaded) use Protected: true/yes and require
+Additionally, mink-* corpora (user-uploaded) use Protected: true with no License field and require
 explicit user grants in JWT scope.
 """
 
@@ -32,7 +33,7 @@ class AuthJWT(utils.Authorizer):
     def get_protected_corpora(self, use_cache: bool = True) -> List[str]:
         """Get list of corpora with restricted access.
 
-        Returns all protected corpora (ACA, RES, and true/yes) as a flat list.
+        Returns all corpora where Protected: true (regardless of License type).
         """
         if use_cache:
             with memcached.get_client() as mc:
@@ -48,7 +49,7 @@ class AuthJWT(utils.Authorizer):
         protected_corpora = []
         for corpus, c_info in corpus_info["corpora"].items():
             protected_value = c_info["info"].get("Protected", "").lower()
-            if protected_value in ("aca", "res", "true", "yes"):
+            if protected_value in ("true", "yes"):
                 protected_corpora.append(corpus.upper())
 
         if use_cache:
@@ -59,10 +60,11 @@ class AuthJWT(utils.Authorizer):
     def check_authorization(self, corpora: List[str]) -> Tuple[bool, List[str], Optional[str]]:
         """Check if user is authorized to access the given corpora.
 
-        Authorization rules:
-        - ACA corpora: User must have ACA (academic) status in JWT
-        - RES corpora: User must have explicit entitlement grant in JWT scope.corpora
-        - true/yes corpora (incl. mink-*): User must have explicit user grant in JWT scope.corpora
+        Authorization rules based on License field:
+        - License: ACA → User must have ACA (academic) status in JWT
+        - License: ACA-Fi → User must have ACA-Fi (Finnish academic) status in JWT
+        - License: RES → User must have explicit entitlement grant in JWT scope.corpora
+        - No License field (mink-* corpora) → User must have explicit user grant in JWT scope.corpora
 
         Returns:
             Tuple of (success, unauthorized_corpora, error_message)
@@ -92,21 +94,29 @@ class AuthJWT(utils.Authorizer):
             for corpus in user_token.get("scope", {}).get("corpora", {}).keys():
                 user_scope_corpora.add(corpus.upper())
 
-        # Get protection types for corpora that need checking
+        # Get license types for corpora that need checking
         corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": corpora_to_check}))
 
         # Check authorization for each corpus
         unauthorized = []
         for corpus_upper in corpora_to_check:
-            protected_value = corpus_info.get("corpora", {}).get(
-                corpus_upper, {}).get("info", {}).get("Protected", "").lower()
+            c_info = corpus_info.get("corpora", {}).get(corpus_upper, {}).get("info", {})
+            license_value = c_info.get("License", "").upper()
 
-            if protected_value == "aca":
-                # ACA corpora require academic status
+            if license_value == "ACA":
+                # ACA license requires academic status
                 if not user_token or not user_token.get("ACA"):
                     unauthorized.append(corpus_upper)
-            elif protected_value in ("res", "true", "yes"):
-                # RES and true/yes corpora require explicit grant in scope
+            elif license_value == "ACA-FI":
+                # ACA-Fi license requires Finnish academic status
+                if not user_token or not user_token.get("ACA-Fi"):
+                    unauthorized.append(corpus_upper)
+            elif license_value == "RES":
+                # RES license requires explicit grant in scope
+                if corpus_upper not in user_scope_corpora:
+                    unauthorized.append(corpus_upper)
+            else:
+                # No License field or other value (e.g., mink-* corpora) requires explicit grant in scope
                 if corpus_upper not in user_scope_corpora:
                     unauthorized.append(corpus_upper)
 

--- a/plugins/auth_jwt.py
+++ b/plugins/auth_jwt.py
@@ -1,19 +1,11 @@
 """Authorization using JWT.
 
-Configuration:
-- licensing_mode: "språkbanken" (default) or "kielipankki"
+For corpora with Protected: true in the .info file:
+- If corpus is in JWT scope.corpora (explicit grant), it's authorized
+- Otherwise, if License field is present in .info, check if JWT has that license key as truthy value
+  (e.g., License: ACA → requires jwt["ACA"], License: ACA-Fi → requires jwt["ACA-Fi"])
+- Otherwise, it's not authorized
 
-Språkbanken mode (upstream/default):
-- All corpora with Protected: true require explicit corpus grant in JWT scope.corpora
-- License field is ignored
-
-Kielipankki mode (extended):
-- License: ACA → Requires JWT ACA flag (academic affiliation)
-- License: ACA-Fi → Requires JWT "ACA-Fi" flag (Finnish academic status)
-- License: RES → Requires explicit grant in JWT scope.corpora
-- No License field → Requires explicit grant in JWT scope.corpora (same as Språkbanken)
-
-Note: .info files use "ACA-Fi" with hyphen, and JWT also uses "ACA-Fi" (quoted key).
 """
 
 import time
@@ -60,13 +52,12 @@ class AuthJWT(utils.Authorizer):
     def check_authorization(self, corpora: List[str]) -> Tuple[bool, List[str], Optional[str]]:
         """Check if user is authorized to access the given corpora.
 
-        Behavior depends on licensing_mode configuration.
+        For corpora with License field: check if JWT has that license key as truthy.
+        For corpora without License field: check if corpus is in JWT scope.corpora.
 
         Returns:
             Tuple of (success, unauthorized_corpora, error_message)
         """
-        licensing_mode = bp.config("licensing_mode", "språkbanken")
-
         protected_set = set(self.get_protected_corpora())
 
         # Find which requested corpora need authorization
@@ -92,50 +83,37 @@ class AuthJWT(utils.Authorizer):
             for corpus in user_token.get("scope", {}).get("corpora", {}).keys():
                 user_scope_corpora.add(corpus.upper())
 
-        # Kielipankki mode: check License field for authorization type
-        if licensing_mode == "kielipankki":
-            # Get license types for corpora that need checking
-            # Always bypass cache for security: .info file changes don't trigger cache invalidation
-            corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": corpora_to_check, "cache": False}))
+        # Get license info for protected corpora
+        # Bypass cache for security: .info file changes don't trigger cache invalidation
+        corpus_info = utils.generator_to_dict(
+            info.corpus_info({"corpus": corpora_to_check, "cache": False})
+        )
 
-            # Check authorization for each corpus
-            unauthorized = []
-            for corpus_upper in corpora_to_check:
-                c_info = corpus_info.get("corpora", {}).get(corpus_upper, {}).get("info", {})
-                license_value = c_info.get("License", "").upper()
+        # Check authorization for each corpus
+        unauthorized = []
+        for corpus_upper in corpora_to_check:
+            if corpus_upper in user_scope_corpora:
+                continue
+            license_value = (
+                corpus_info.get("corpora", {})
+                .get(corpus_upper, {})
+                .get("info", {})
+                .get("License", "")
+            )
+            if license_value and user_token.get(license_value):
+                continue
+            unauthorized.append(corpus_upper)
 
-                if license_value == "ACA":
-                    # ACA license requires academic status
-                    if not user_token or not user_token.get("ACA"):
-                        unauthorized.append(corpus_upper)
-                elif license_value == "ACA-Fi":
-                    # ACA-Fi license requires Finnish academic status
-                    if not user_token or not user_token.get("ACA-Fi"):
-                        unauthorized.append(corpus_upper)
-                elif license_value == "RES":
-                    # RES license requires explicit grant in scope
-                    if corpus_upper not in user_scope_corpora:
-                        unauthorized.append(corpus_upper)
-                else:
-                    # No License field or other value requires explicit grant in scope
-                    if corpus_upper not in user_scope_corpora:
-                        unauthorized.append(corpus_upper)
-
-            if unauthorized:
-                return False, unauthorized, None
-            return True, [], None
-
-        # Default mode (Språkbanken): all protected corpora require explicit grant in scope
-        else:
-            unauthorized = [c.upper() for c in corpora_to_check if c.upper() not in user_scope_corpora]
-            if unauthorized:
-                return False, unauthorized, None
-            return True, [], None
+        if unauthorized:
+            return False, unauthorized, None
+        return True, [], None
 
     @property
     def jwt_key(self):
         """Return the public key for validating JWTs."""
         if not self._pubkey:
             if bp.config("pubkey_file"):
-                self._pubkey = open(Path(app.instance_path) / bp.config("pubkey_file")).read()
+                self._pubkey = open(
+                    Path(app.instance_path) / bp.config("pubkey_file")
+                ).read()
         return self._pubkey

--- a/plugins/auth_jwt.py
+++ b/plugins/auth_jwt.py
@@ -1,13 +1,19 @@
 """Authorization using JWT.
 
-Supports multiple access levels based on License type:
-- PUB (public): Protected: false or absent in .info, accessible to all
-- ACA (academic): Protected: true, License: ACA - requires academic affiliation (JWT ACA flag)
-- ACA-Fi (Finnish academic): Protected: true, License: ACA-Fi - requires Finnish academic status (JWT ACA-Fi flag)
-- RES (restricted): Protected: true, License: RES - requires explicit entitlement grant in JWT scope
+Configuration:
+- licensing_mode: "språkbanken" (default) or "kielipankki"
 
-Additionally, mink-* corpora (user-uploaded) use Protected: true with no License field and require
-explicit user grants in JWT scope.
+Språkbanken mode (upstream/default):
+- All corpora with Protected: true require explicit corpus grant in JWT scope.corpora
+- License field is ignored
+
+Kielipankki mode (extended):
+- License: ACA → Requires JWT ACA flag (academic affiliation)
+- License: ACA-Fi → Requires JWT ACA_Fi flag (Finnish academic status)
+- License: RES → Requires explicit grant in JWT scope.corpora
+- No License field → Requires explicit grant in JWT scope.corpora (same as Språkbanken)
+
+Note: .info files use "ACA-Fi" with hyphen, but JWT uses "ACA_Fi" with underscore.
 """
 
 import time
@@ -60,15 +66,13 @@ class AuthJWT(utils.Authorizer):
     def check_authorization(self, corpora: List[str]) -> Tuple[bool, List[str], Optional[str]]:
         """Check if user is authorized to access the given corpora.
 
-        Authorization rules based on License field:
-        - License: ACA → User must have ACA (academic) status in JWT
-        - License: ACA-Fi → User must have ACA-Fi (Finnish academic) status in JWT
-        - License: RES → User must have explicit entitlement grant in JWT scope.corpora
-        - No License field (mink-* corpora) → User must have explicit user grant in JWT scope.corpora
+        Behavior depends on licensing_mode configuration.
 
         Returns:
             Tuple of (success, unauthorized_corpora, error_message)
         """
+        licensing_mode = bp.config("licensing_mode", "språkbanken")
+
         protected_set = set(self.get_protected_corpora())
 
         # Find which requested corpora need authorization
@@ -94,6 +98,14 @@ class AuthJWT(utils.Authorizer):
             for corpus in user_token.get("scope", {}).get("corpora", {}).keys():
                 user_scope_corpora.add(corpus.upper())
 
+        # Språkbanken mode: all protected corpora require explicit grant in scope
+        if licensing_mode == "språkbanken":
+            unauthorized = [c.upper() for c in corpora_to_check if c.upper() not in user_scope_corpora]
+            if unauthorized:
+                return False, unauthorized, None
+            return True, [], None
+
+        # Kielipankki mode: check License field for authorization type
         # Get license types for corpora that need checking
         corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": corpora_to_check}))
 
@@ -109,14 +121,14 @@ class AuthJWT(utils.Authorizer):
                     unauthorized.append(corpus_upper)
             elif license_value == "ACA-FI":
                 # ACA-Fi license requires Finnish academic status
-                if not user_token or not user_token.get("ACA-Fi"):
+                if not user_token or not user_token.get("ACA_Fi"):
                     unauthorized.append(corpus_upper)
             elif license_value == "RES":
                 # RES license requires explicit grant in scope
                 if corpus_upper not in user_scope_corpora:
                     unauthorized.append(corpus_upper)
             else:
-                # No License field or other value (e.g., mink-* corpora) requires explicit grant in scope
+                # No License field or other value requires explicit grant in scope
                 if corpus_upper not in user_scope_corpora:
                     unauthorized.append(corpus_upper)
 

--- a/plugins/auth_jwt.py
+++ b/plugins/auth_jwt.py
@@ -40,27 +40,21 @@ class AuthJWT(utils.Authorizer):
         """Get list of corpora with restricted access.
 
         Returns all corpora where Protected: true (regardless of License type).
-        """
-        if use_cache:
-            with memcached.get_client() as mc:
-                key = f"protected:{utils.cache_prefix(mc)}"
-                result = mc.get(key)
-            if result is not None:
-                return result
 
-        # Get list of all corpora from CWB
+        Note: Caching is disabled for security. The cache invalidation system only
+        monitors registry files, not .info files, so cached protection status could
+        become stale when .info files are edited.
+        """
+        # Always bypass cache for security: .info file changes don't trigger cache invalidation
         corpora = cwb.run_cqp("show corpora;")
         next(corpora)  # Skip version number
-        corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": list(corpora)}))
+        corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": list(corpora), "cache": False}))
         protected_corpora = []
         for corpus, c_info in corpus_info["corpora"].items():
             protected_value = c_info["info"].get("Protected", "").lower()
             if protected_value in ("true", "yes"):
                 protected_corpora.append(corpus.upper())
 
-        if use_cache:
-            with memcached.get_client() as mc:
-                mc.add(key, protected_corpora)
         return protected_corpora
 
     def check_authorization(self, corpora: List[str]) -> Tuple[bool, List[str], Optional[str]]:
@@ -107,7 +101,8 @@ class AuthJWT(utils.Authorizer):
 
         # Kielipankki mode: check License field for authorization type
         # Get license types for corpora that need checking
-        corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": corpora_to_check}))
+        # Always bypass cache for security: .info file changes don't trigger cache invalidation
+        corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": corpora_to_check, "cache": False}))
 
         # Check authorization for each corpus
         unauthorized = []


### PR DESCRIPTION
check_authorization() will now know to check ACA status in the JWT for ACA corpora, and specific grants for RES and mink corpora.