### PR TITLE
KP-10997 Check .info files too in corpus timestamps

### DIFF
--- a/korp/utils.py
+++ b/korp/utils.py
@@ -356,9 +356,29 @@ class CustomTracebackException(Exception):
 
 
 def get_corpus_timestamps():
-    """Get modification time of corpus registry files."""
-    corpora = dict((os.path.basename(f).upper(), os.path.getmtime(f)) for f in
-                   glob.glob(os.path.join(app.config["CWB_REGISTRY"], "*")))
+    """Get modification time of corpus registry files and associated .info files.
+
+    Returns the latest modification time between the registry file and its .info file.
+    Info files are located at registry_dir/../data/corpus_name/.info
+    """
+    registry_dir = app.config["CWB_REGISTRY"]
+    data_dir = os.path.join(os.path.dirname(registry_dir), "data")
+
+    corpora = {}
+    for registry_file in glob.glob(os.path.join(registry_dir, "*")):
+        corpus_name = os.path.basename(registry_file).upper()
+        registry_mtime = os.path.getmtime(registry_file)
+
+        # Check if there's a corresponding .info file
+        info_file = os.path.join(data_dir, os.path.basename(registry_file), ".info")
+        if os.path.isfile(info_file):
+            info_mtime = os.path.getmtime(info_file)
+            # Use the latest modification time
+            corpora[corpus_name] = max(registry_mtime, info_mtime)
+        else:
+            # No .info file, just use registry file timestamp
+            corpora[corpus_name] = registry_mtime
+
     return corpora
 
 

--- a/plugins/auth_jwt.py
+++ b/plugins/auth_jwt.py
@@ -40,21 +40,27 @@ class AuthJWT(utils.Authorizer):
         """Get list of corpora with restricted access.
 
         Returns all corpora where Protected: true (regardless of License type).
-
-        Note: Caching is disabled for security. The cache invalidation system only
-        monitors registry files, not .info files, so cached protection status could
-        become stale when .info files are edited.
         """
-        # Always bypass cache for security: .info file changes don't trigger cache invalidation
+        if use_cache:
+            with memcached.get_client() as mc:
+                key = f"protected:{utils.cache_prefix(mc)}"
+                result = mc.get(key)
+            if result is not None:
+                return result
+
+        # Get list of all corpora from CWB
         corpora = cwb.run_cqp("show corpora;")
         next(corpora)  # Skip version number
-        corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": list(corpora), "cache": False}))
+        corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": list(corpora)}))
         protected_corpora = []
         for corpus, c_info in corpus_info["corpora"].items():
             protected_value = c_info["info"].get("Protected", "").lower()
             if protected_value in ("true", "yes"):
                 protected_corpora.append(corpus.upper())
 
+        if use_cache:
+            with memcached.get_client() as mc:
+                mc.add(key, protected_corpora)
         return protected_corpora
 
     def check_authorization(self, corpora: List[str]) -> Tuple[bool, List[str], Optional[str]]:
@@ -95,8 +101,7 @@ class AuthJWT(utils.Authorizer):
         # Kielipankki mode: check License field for authorization type
         if licensing_mode == "kielipankki":
             # Get license types for corpora that need checking
-            # Always bypass cache for security: .info file changes don't trigger cache invalidation
-            corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": corpora_to_check, "cache": False}))
+            corpus_info = utils.generator_to_dict(info.corpus_info({"corpus": corpora_to_check}))
 
             # Check authorization for each corpus
             unauthorized = []


### PR DESCRIPTION
This is in order to invalidate the cache if .info files (where protected status lives) changes, so that authorization caches change too.